### PR TITLE
feat: automatically publish to Hex.pm from release tag

### DIFF
--- a/.github/workflows/publish2hex.yml
+++ b/.github/workflows/publish2hex.yml
@@ -1,0 +1,17 @@
+name: publish2hex
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish2hex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v3
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
To use this feature, please setup `HEX_API_KEY` according to following page 🥇 
https://github.com/marketplace/actions/publish-to-hex